### PR TITLE
kitty.rb: fixed deprecated dependency declaration style

### DIFF
--- a/Formula/kitty.rb
+++ b/Formula/kitty.rb
@@ -4,7 +4,7 @@ class Kitty < Formula
   revision 1
   head "https://github.com/cema-sp/kitty.git", :using => :git
 
-  depends_on :python3
+  depends_on "python3"
   depends_on "glfw"
   depends_on "pkg-config" => :build
 


### PR DESCRIPTION
I was getting the warning:

```
Warning: Calling 'depends_on :python3' is deprecated!
Use 'depends_on "python3"' instead.
/usr/local/Homebrew/Library/Taps/cema-sp/homebrew-tap/Formula/kitty.rb:7:in `<class:Kitty>'
```

This fixed it.