### PR TITLE
Fix `'depends_on :python3' is disabled!`

### DIFF
--- a/Formula/kitty.rb
+++ b/Formula/kitty.rb
@@ -4,7 +4,7 @@ class Kitty < Formula
   revision 1
   head "https://github.com/cema-sp/kitty.git", :using => :git
 
-  depends_on :python3
+  depends_on "python"
   depends_on "glfw"
   depends_on "pkg-config" => :build
 


### PR DESCRIPTION
According to the error message this should hopefully fix issue #7 _**`depends_on :python3 is disabled`**_
I ran into it myself.
### Error Message
```
Mac:~ ashrafhadden$ brew install --HEAD cema-sp/homebrew-tap/alacritty
==> Tapping cema-sp/tap
Cloning into '/usr/local/Homebrew/Library/Taps/cema-sp/homebrew-tap'...
remote: Counting objects: 8, done.
remote: Compressing objects: 100% (8/8), done.
remote: Total 8 (delta 0), reused 6 (delta 0), pack-reused 0
Unpacking objects: 100% (8/8), done.
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/cema-sp/homebrew-tap/Formula/kitty.rb
Calling 'depends_on :python3' is disabled!
Use 'depends_on "python"' instead.
/usr/local/Homebrew/Library/Taps/cema-sp/homebrew-tap/Formula/kitty.rb:7:in `<class:Kitty>'
Please report this to the cema-sp/tap tap!
Or, even better, submit a PR to fix it!
Error: Cannot tap cema-sp/tap: invalid syntax in tap!
Mac:~ ashrafhadden$ 
```